### PR TITLE
Dont save results

### DIFF
--- a/servicemon/query.py
+++ b/servicemon/query.py
@@ -35,9 +35,9 @@ class Query():
     """
 
     def __init__(self, service, coords, radius, out_dir, use_subdir=True,
-                 agent='NAVO-servicemon', tap_mode='async', use_pyvo=True,
+                 agent='NAVO-servicemon', tap_mode='async', save_results=True,
                  verbose=False):
-        self._use_pyvo = use_pyvo
+        self._save_results = save_results
 
         self._timer = Timer('query_total', logger=None)
         self._timer.timers.clear()
@@ -160,11 +160,7 @@ class Query():
             self._stats.add_interval(Interval(items[0], items[1]))
 
         result_meta = dict.fromkeys(self._result_meta_attrs())
-
-        if self._service_type == 'cone' or self._use_pyvo:
-            result_meta['status'] = response.status_code
-        elif self._service_type == 'tap':
-            result_meta['status'] = response.status
+        result_meta['status'] = response.status_code
 
         try:
             with warnings.catch_warnings():
@@ -174,6 +170,9 @@ class Query():
             result_meta['size'] = os.path.getsize(self._filename)
             result_meta['num_rows'] = len(t)
             result_meta['num_columns'] = len(t.columns)
+
+            if not self._save_results:
+                os.remove(self._filename)
         except Exception as e:
             msg = f'In {self._query_name}, error reading result table: {repr(e)}'
             self._handle_exc(msg)

--- a/servicemon/query.py
+++ b/servicemon/query.py
@@ -99,7 +99,12 @@ class Query():
 
     @time_this('do_query')
     def do_tap_query_async_pyvo(self, tap_service):
-        response = tap_service.run_async_timed(self._adql, response_only=True)
+        response = tap_service.run_async_timed(self._adql, streamable_response=True)
+        return response
+
+    @time_this('do_query')
+    def do_tap_query_pyvo(self, tap_service):
+        response = tap_service.run_sync_timed(self._adql, streamable_response=True)
         return response
 
     @time_this('do_query')
@@ -111,13 +116,6 @@ class Query():
     def do_xcone_query(self):
         response = self.do_request(self._access_url)
         return response
-
-    @time_this('stream_to_file')
-    def stream_tap_to_file(self, response):
-        result_content = response.read()
-        os.makedirs(os.path.dirname(self._filename), exist_ok=True)
-        with open(self._filename, 'wb+') as fd:
-            fd.write(result_content)
 
     @time_this('stream_to_file')
     def stream_to_file(self, response):

--- a/servicemon/query_runner.py
+++ b/servicemon/query_runner.py
@@ -17,7 +17,7 @@ class QueryRunner():
 
     def __init__(self, services, cones, result_dir='.', stats_path=None,
                  starting_cone=0, cone_limit=100000000, tap_mode='async',
-                 use_pyvo=True, verbose=True):
+                 save_results=True, verbose=True):
         """
         """
         self._services = self._read_if_file(services)
@@ -27,7 +27,7 @@ class QueryRunner():
         self._starting_cone = int(starting_cone)
         self._cone_limit = int(cone_limit)
         self._tap_mode = tap_mode
-        self._use_pyvo = use_pyvo
+        self._save_results = save_results
         self._verbose = verbose
 
         if self._stats_path is not None:
@@ -56,7 +56,7 @@ class QueryRunner():
                         query = Query(service, (cone['ra'], cone['dec']),
                                       cone['radius'], self._result_dir,
                                       tap_mode=self._tap_mode,
-                                      use_pyvo=self._use_pyvo,
+                                      save_results=self._save_results,
                                       verbose=self._verbose)
                         query.run()
                     except Exception as e:
@@ -75,7 +75,7 @@ class QueryRunner():
             try:
                 query = Query(service, None, None, self._result_dir,
                               tap_mode=self._tap_mode,
-                              use_pyvo=self._use_pyvo,
+                              save_results=self._save_results,
                               verbose=self._verbose)
                 query.run()
             except Exception as e:

--- a/servicemon/run_utils.py
+++ b/servicemon/run_utils.py
@@ -34,13 +34,14 @@ class Runner():
                             help='Catch SIGHUP, SIGQUIT and SIGTERM'
                             ' to allow running in the background')
         parser.add_argument('-s', '--save-results', dest='save_results', action='store_true',
-                            help='Save the query result data files.  Without this argument,'
-                            'the query result files will be deleted after metadata is gathered.')
+                            help='Save the query result data files.  Without this argument, '
+                            'the query result file will be deleted after metadata is gathered '
+                            'for the query.')
         parser.add_argument('-t', '--tap-mode', dest='tap_mode',
                             choices={'sync', 'async'}, default='async',
-                            help='How to run TAP queries')
+                            help='How to run TAP queries (default=async)')
         parser.add_argument('-n', '--norun', dest='norun', action='store_true',
-                            help='Display summary of command arguments without'
+                            help='Display summary of command arguments without '
                             'performing any actions')
         parser.add_argument('-r', '--result-dir', dest='result_dir', default='results',
                             help='The directory in which to put query result files.')

--- a/servicemon/run_utils.py
+++ b/servicemon/run_utils.py
@@ -33,9 +33,9 @@ class Runner():
         parser.add_argument('-b', '--batch', dest='batch', action='store_true',
                             help='Catch SIGHUP, SIGQUIT and SIGTERM'
                             ' to allow running in the background')
-        parser.add_argument('-u', '--use-pyvo', dest='use_pyvo', action='store_true',
-                            help='Use PyVO for queries'
-                            ' to allow running in the background')
+        parser.add_argument('-s', '--save-results', dest='save_results', action='store_true',
+                            help='Save the query result data files.  Without this argument,'
+                            'the query result files will be deleted after metadata is gathered.')
         parser.add_argument('-t', '--tap-mode', dest='tap_mode',
                             choices={'sync', 'async'}, default='async',
                             help='How to run TAP queries')
@@ -201,7 +201,7 @@ min-radius: {args.min_radius}, max-radius: {args.max_radius}''')
     def replay(self, pa):
         qr = QueryRunner(pa.file, None, result_dir=pa.result_dir,
                          stats_path=pa.output, tap_mode=pa.tap_mode,
-                         use_pyvo=pa.use_pyvo,
+                         save_results=pa.save_results,
                          verbose=pa.verbose)
         qr.run()
 
@@ -209,7 +209,7 @@ min-radius: {args.min_radius}, max-radius: {args.max_radius}''')
         qr = QueryRunner(pa.services, pa.cone_file, result_dir=pa.result_dir,
                          stats_path=pa.output, starting_cone=pa.start_index,
                          cone_limit=pa.cone_limit,
-                         use_pyvo=pa.use_pyvo,
+                         save_results=pa.save_results,
                          tap_mode=pa.tap_mode, verbose=pa.verbose)
         qr.run()
 
@@ -217,7 +217,7 @@ min-radius: {args.min_radius}, max-radius: {args.max_radius}''')
         random_cones = Cone.generate_random(pa.num_cones, pa.min_radius, pa.max_radius)
         qr = QueryRunner(pa.services, random_cones, result_dir=pa.result_dir,
                          stats_path=pa.output, tap_mode=pa.tap_mode,
-                         use_pyvo=pa.use_pyvo,
+                         save_results=pa.save_results,
                          verbose=pa.verbose)
         qr.run()
 

--- a/servicemon/tests/test_run_utils.py
+++ b/servicemon/tests/test_run_utils.py
@@ -43,20 +43,23 @@ def test_global_args(capsys):
     assert args.tap_mode == 'sync'
     assert not args.norun
     assert not args.verbose
+    assert not args.save_results
 
-    args = parse_args(['--batch', '--norun', '--verbose',
+    args = parse_args(['--batch', '--norun', '--verbose', '--save-results',
                        'replay', 'testfile.csv', 'outfile.csv'])
     assert args.batch
     assert args.tap_mode == 'async'
     assert args.norun
     assert args.verbose
+    assert args.save_results
 
-    args = parse_args(['-b', '-n', '-v',
+    args = parse_args(['-b', '-n', '-v', '-s',
                        'replay', 'testfile.csv', 'outfile.csv'])
     assert args.batch
     assert args.tap_mode == 'async'
     assert args.norun
     assert args.verbose
+    assert args.save_results
 
     check_err_msg(capsys, ['replay', '-b', 'testfile.csv', 'outfile.csv'],
                   'error: unrecognized arguments: -b')


### PR DESCRIPTION
Includes these changes:

- Add --save-results option to save query result VOTables (default to False to save space)
- Reenable capability to do synchronous TAP queries
- Remove the unused --use-pyvo option (Astroquery TAPPlus no longer an option)
